### PR TITLE
programmer: remove useless h function

### DIFF
--- a/programmer/tinyfpgab.py
+++ b/programmer/tinyfpgab.py
@@ -4,10 +4,6 @@ import struct
 import time
 
 
-def h(a):
-    return ' '.join("%02X" % i for i in a)
-
-
 class TinyFPGAB(object):
     def __init__(self, ser, progress=None):
         self.ser = ser


### PR DESCRIPTION
Since https://github.com/tinyfpga/TinyFPGA-Programmer-Application/issues/2 is now closed, we can remove the useless `h` function, and achieve 100% code coverage on the programmer (well, the `__main__` part is not tested, but that's another story)!