### PR TITLE
Improve travis-ci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,7 @@ sudo: false
 language: python
 python:
   - "2.7"
-install: pip install tox-travis
-script: tox
+install:
+  - pip install tox-travis
+script:
+  - cd programmer && tox

--- a/programmer/tox.ini
+++ b/programmer/tox.ini
@@ -8,5 +8,5 @@ deps =
     pytest-pep8
     pytest-cov
 commands=
-    py.test --pep8 --cov --cov-report term-missing programmer/tinyfpgab.py programmer/test.py
+    py.test --pep8 --cov --cov-report term-missing tinyfpgab.py test.py
     py27: coverage html


### PR DESCRIPTION
Adding the travis-ci build for the programmer is great!

However, I see you moved the `tox.ini` file into the root of the repository, but this causes a few issues I think:

 * it is specific to the programmer, so it makes sense to keep it in the `programmer` directory
 * the `.coveragerc` and `.gitignore` from the programmer directory are getting ignored, so travis-ci is testing coverage for things we don't want (e.g. python libraries)

This pull request is moving back the `tox.ini` file in the `programmer` directory to correct these issues.

I'm basing this on https://lord.io/blog/2014/travis-multiple-subdirs/, tell me if you think it is not the best idea.