### PR TITLE
Fix VID/PID containing letters not being matched

### DIFF
--- a/programmer/tinyfpgab/__main__.py
+++ b/programmer/tinyfpgab/__main__.py
@@ -34,7 +34,7 @@ def main():
         sys.exit(1)
     device = '{}:{}'.format(device[:4], device[4:])
     print "    Using device id {}".format(device)
-    active_boards = [p[0] for p in comports() if device in p[2]]
+    active_boards = [p[0] for p in comports() if device in p[2].lower()]
 
     # find port to use
     active_port = None


### PR DESCRIPTION
On Linux, comports() returns an all uppercase result, so any programmer which vid/pid contains letters is not going to match.

Fixes programmer-arduino on a lot of SAMD boards (3.3V so no level translator needed)