### PR TITLE
Add exit(1) if programming is not successful

### DIFF
--- a/programmer/tinyfpgab/__main__.py
+++ b/programmer/tinyfpgab/__main__.py
@@ -96,6 +96,10 @@ def main():
                            writeTimeout=0.2) as ser:
             fpga = TinyFPGAB(ser)
             fpga.boot()
+    else:
+        # exit with error if programming is not successful
+        sys.exit(1)
+
 
 if __name__ == '__main__':
     main()

--- a/programmer/tinyfpgab/__main__.py
+++ b/programmer/tinyfpgab/__main__.py
@@ -96,10 +96,9 @@ def main():
                            writeTimeout=0.2) as ser:
             fpga = TinyFPGAB(ser)
             fpga.boot()
-    else:
+    elif args.program is not None:
         # exit with error if programming is not successful
         sys.exit(1)
-
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This is required to detect the error in programming for APIO and Icestudio.