### PR TITLE
Manage Serial exceptions

### DIFF
--- a/programmer/setup.py
+++ b/programmer/setup.py
@@ -1,18 +1,18 @@
 from setuptools import setup, find_packages
 setup(
-  name = 'tinyfpgab',
-  packages = find_packages(),
-  install_requires = ['pyserial'],
-  version = '1.0.3',
-  description = 'Programmer for the TinyFPGA B-Series boards (http://tinyfpga.com)',
-  author = 'Luke Valenty',
-  author_email = 'lvalenty@gmail.com',
-  url = 'https://github.com/tinyfpga/TinyFPGA-B-Series/tree/master/programmer', 
-  keywords = ['fpga', 'tinyfpga', 'programmer'], 
-  classifiers = [],
-  entry_points = {
-    'console_scripts': [
-        'tinyfpgab = tinyfpgab.__main__:main'    
-    ]    
-  },
+    name='tinyfpgab',
+    packages=find_packages(),
+    install_requires=['pyserial'],
+    version='1.0.3',
+    description='Programmer for the TinyFPGA B-Series boards (http://tinyfpga.com)',
+    author='Luke Valenty',
+    author_email='lvalenty@gmail.com',
+    url='https://github.com/tinyfpga/TinyFPGA-B-Series/tree/master/programmer',
+    keywords=['fpga', 'tinyfpga', 'programmer'],
+    classifiers=[],
+    entry_points={
+        'console_scripts': [
+            'tinyfpgab = tinyfpgab.__main__:main'
+        ]
+    }
 )

--- a/programmer/tinyfpgab/__init__.py
+++ b/programmer/tinyfpgab/__init__.py
@@ -50,7 +50,7 @@ class TinyFPGAB(object):
         return self.cmd(0x9f, read_len=3)
 
     def read_sts(self):
-        return self.cmd(0x05, read_len=1)
+        return self.cmd(0x05, read_len=1) or '1'
 
     def read(self, addr, length):
         data = ''

--- a/programmer/tinyfpgab/__main__.py
+++ b/programmer/tinyfpgab/__main__.py
@@ -1,7 +1,9 @@
-def main():
-    import sys
+import sys
+import serial
+
+
+def _main():
     import argparse
-    import serial
     from serial.tools.list_ports import comports
     from tinyfpgab import TinyFPGAB
 
@@ -96,6 +98,15 @@ def main():
                            writeTimeout=0.2) as ser:
             fpga = TinyFPGAB(ser)
             fpga.boot()
+
+
+def main():
+    try:
+        _main()
+    except serial.SerialException as e:
+        print "    Error: {}".format(e)
+        sys.exit(1)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
### Changes

This changes will be used to detect and notify the TinyFPGA B2 errors in Icestudio.

- Manage Serial exceptions: catch `serial.SerialException` exceptions and print in a proper format.
- Avoid exception "TypeError: ord() expected a character, but string of length 0 found" when Reset is pressed during upload.
- Bonus: fix setup.py indentation

### Exceptions

**Device or resource busy**

This error appears in Linux quite often. Btw, it is solved with `apio drivers --serial-enable` (disabling ModemManager).

Before
```
Traceback (most recent call last):
File "/home/jesus/.local/bin/tinyfpgab", line 11, in <module>
load_entry_point('tinyfpgab==1.0.3', 'console_scripts', 'tinyfpgab')()
File "/home/jesus/.local/lib/python2.7/site-packages/tinyfpgab/__main__.py", line 72, in main
writeTimeout=0.2) as ser:
File "/home/jesus/.local/lib/python2.7/site-packages/serial/serialutil.py", line 240, in __init__
self.open()
File "/home/jesus/.local/lib/python2.7/site-packages/serial/serialposix.py", line 268, in open
raise SerialException(msg.errno, "could not open port {}: {}".format(self._port, msg))
serial.serialutil.SerialException: [Errno 16] could not open port /dev/ttyACM0: [Errno 16] Device or resource busy: '/dev/ttyACM0'
```
After
```
Error: [Errno 16] could not open port /dev/ttyACM0: [Errno 16] Device or resource busy: '/dev/ttyACM0'
```

**Device disconnected**

This error appears when you press the RESET button during programming

Before
```
Traceback (most recent call last):
File "/home/jesus/.local/bin/tinyfpgab", line 11, in <module>
load_entry_point('tinyfpgab==1.0.3', 'console_scripts', 'tinyfpgab')()
File "/home/jesus/.local/lib/python2.7/site-packages/tinyfpgab/__main__.py", line 87, in main
if fpga.program_bitstream(addr, bitstream):
File "/home/jesus/.local/lib/python2.7/site-packages/tinyfpgab/__init__.py", line 240, in program_bitstream
if self.program(addr, bitstream):
File "/home/jesus/.local/lib/python2.7/site-packages/tinyfpgab/__init__.py", line 164, in program
self.erase(addr, len(data))
File "/home/jesus/.local/lib/python2.7/site-packages/tinyfpgab/__init__.py", line 134, in erase
self._erase(addr, erase_length)
File "/home/jesus/.local/lib/python2.7/site-packages/tinyfpgab/__init__.py", line 89, in _erase
self.wait_while_busy()
File "/home/jesus/.local/lib/python2.7/site-packages/tinyfpgab/__init__.py", line 78, in wait_while_busy
while ord(self.read_sts()) & 1:
TypeError: ord() expected a character, but string of length 0 found
```
After
```
Error: device reports readiness to read but returned no data (device disconnected or multiple access on port?)
```